### PR TITLE
added comment pointing to parameter

### DIFF
--- a/src/ydlidar_node.cpp
+++ b/src/ydlidar_node.cpp
@@ -355,7 +355,7 @@ int main(int argc, char * argv[]) {
     nh_private.param<double>("range_max", max_range , 16.0);
     nh_private.param<double>("range_min", min_range , 0.08);
     nh_private.param<double>("frequency", _frequency , 7.0);
-    nh_private.param<double>("range_error", range_error, 0.0);
+    nh_private.param<double>("range_error", range_error, 0.0); // usually only need to tweak this value to fix lidar error
     nh_private.param<double>("range_at_error", range_at_error, 4.0);
     nh_private.param<double>("baseline", baseline, 0.035);
     nh_private.param<std::string>("ignore_array",list,"");


### PR DESCRIPTION
Description:

This PR introduces a correction mechanism for the YDLidar triangulation process to account for small errors in angle measurement. These errors can occur due to manufacturing variations or physical impacts on the lidar. The correction ensures more accurate distance estimations.

Changes:
Implemented a correction mechanism to adjust for angle errors in the triangulation process.

Added new parameters to the launch file to allow users to tweak the range error correction:


```
<!-- parameter to tweak: range_error (usually in [-0.25, 0.25] for range_at_error ~ 4) -->
<param name="range_error"  type="double" value="0.2"/>
<param name="range_at_error" type="double" value="4.0"/>
<param name="baseline"     type="double" value="0.035"/> 
```
Typically, you'd only need to adjust `range_error`.


